### PR TITLE
[adguard-home] Allow to backup the Adguard Home configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rm3l)](https://artifacthub.io/packages/search?repo=rm3l)
-[![adguard-home](https://img.shields.io/badge/adguard--home-0.1.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![adguard-home](https://img.shields.io/badge/adguard--home-0.2.1-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 [![dev-feed](https://img.shields.io/badge/dev--feed-1.4.0-blue)](https://artifacthub.io/packages/helm/rm3l/dev-feed)
 [![ghost-export-to-s3](https://img.shields.io/badge/ghost--export--to--s3-0.20.0-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)
 [![mac-oui](https://img.shields.io/badge/mac--oui-1.19.0-blue)](https://artifacthub.io/packages/helm/rm3l/mac-oui)

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -3,13 +3,13 @@
 Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.1.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.2.1-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.1.0
+$ helm install my-adguard-home rm3l/adguard-home --version 0.2.1
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
@@ -23,6 +23,20 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| backup.activeDeadlineSeconds | int | `1800` |  |
+| backup.aws.accessKeyId | string | `"my-aws-access-key-id"` | AWS Access Key. Must have the permissions to write to the target bucket. |
+| backup.aws.enabled | bool | `true` | For now, only AWS is supported. Setting this to `false` (while `backup.enabled` is `true`) will cause a deployment error. |
+| backup.aws.s3 | object | `{"destination":"s3://path/to/my/adguard-home-s3-export.json"}` | Target destination (absolute) in AWS S3, where the backup file should be written |
+| backup.aws.secretKey | string | `"my-aws-secret-key"` | AWS Secret Key. Must have the permissions to write to the target bucket. |
+| backup.backoffLimit | int | `1` |  |
+| backup.concurrencyPolicy | string | `"Forbid"` |  |
+| backup.enabled | bool | `false` | Note that this depends on the Access Mode set for the persistent volume claim (PVC) specified. -- As a consequence, backups will not be possible if the PVC access mode is set to ReadWriteOncePod (Kubernetes 1.22+), -- since the volume will be accessible only to the sole Adguard Home pod. |
+| backup.imagePullPolicy | string | `"IfNotPresent"` |  |
+| backup.parallelism | int | `1` |  |
+| backup.resources | object | `{}` |  |
+| backup.restartPolicy | string | `"OnFailure"` |  |
+| backup.schedule | string | `"@daily"` | How frequently the Backup job should run. Cron Syntax, as supported by Kubernetes CronJobs |
+| backup.ttlSecondsAfterFinished | int | `300` |  |
 | bootstrapConfig.auth_attempts | int | `5` |  |
 | bootstrapConfig.beta_bind_port | int | `0` |  |
 | bootstrapConfig.bind_host | string | `"0.0.0.0"` | AdGuard Home config. See [this page](https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration#configuration-file) |

--- a/charts/adguard-home/templates/_helpers.tpl
+++ b/charts/adguard-home/templates/_helpers.tpl
@@ -51,6 +51,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Common labels
+*/}}
+{{- define "adguard-home.backupLabels" -}}
+helm.sh/chart: {{ include "adguard-home.chart" . }}
+{{ include "adguard-home.backupSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "adguard-home.backupSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "adguard-home.name" . }}-backup
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "adguard-home.serviceAccountName" -}}

--- a/charts/adguard-home/templates/backup.secret.yaml
+++ b/charts/adguard-home/templates/backup.secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "adguard-home.fullname" . }}-backup
+  labels:
+    {{- include "adguard-home.labels" . | nindent 4 }}
+data:
+{{- if .Values.backup.aws.enabled }}
+  AWS_ACCESS_KEY_ID: {{ .Values.backup.aws.accessKeyId | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY:  {{ .Values.backup.aws.secretKey | b64enc | quote }}
+  S3_DESTINATION: {{ .Values.backup.aws.s3.destination | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/adguard-home/templates/cronjob.yaml
+++ b/charts/adguard-home/templates/cronjob.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.backup.enabled -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: batch/v1
+{{- else -}}
+apiVersion: batch/v1beta1
+{{- end }}
+kind: CronJob
+metadata:
+  name: {{ include "adguard-home.fullname" . }}-backup
+  labels:
+    {{- include "adguard-home.backupLabels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.backup.schedule }}"
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished }}
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      parallelism: {{ .Values.backup.parallelism }}
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
+      template:
+        metadata: 
+          annotations:
+            checksum/secret: {{ include (print $.Template.BasePath "/backup.secret.yaml") . | sha256sum }}
+            {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: {{ .Values.backup.restartPolicy }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          serviceAccountName: {{ include "adguard-home.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          volumes:
+          - name: data-vol
+            persistentVolumeClaim:
+              claimName: {{ include "adguard-home.fullname" . }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- if has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes) }}
+          {{- /*
+          Force-scheduling the job on the node running the AdguardHome pod.
+          # Otherwise, the job may never run if scheduled on a different node.
+          */}}
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    {{- include "adguard-home.selectorLabels" . | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
+          {{- else }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+
+          containers:
+          - name: backup-adguard-home-config
+            imagePullPolicy: {{ .Values.backup.imagePullPolicy }}
+            volumeMounts:
+            - name: data-vol
+              mountPath: /opt/adguardhome/conf
+              subPath: conf
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+            {{- if .Values.backup.aws.enabled }}
+            image: amazon/aws-cli:2.4.9
+            args:
+            - s3
+            - cp
+            - "/opt/adguardhome/conf/AdGuardHome.yaml"
+            - "$(S3_DESTINATION)"
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "adguard-home.fullname" . }}-backup
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "adguard-home.fullname" . }}-backup
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: S3_DESTINATION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "adguard-home.fullname" . }}-backup
+                  key: S3_DESTINATION
+            {{- end }}
+{{- end }}

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -129,9 +129,24 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (.Values.backup.enabled) (has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes)) }}
+      affinity:
+        podAffinity:
+          {{- /*
+          # Add soft affinity to avoid race condition when backup cronjob already runs and has the volume mounted
+          */}}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  {{- include "adguard-home.backupSelectorLabels" . | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      {{- else}}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -156,6 +156,32 @@ persistence:
       requests:
         storage: 1Gi
 
+backup:
+  # -- Note that this depends on the Access Mode set for the persistent volume claim (PVC) specified.
+  # -- As a consequence, backups will not be possible if the PVC access mode is set to ReadWriteOncePod (Kubernetes 1.22+),
+  # -- since the volume will be accessible only to the sole Adguard Home pod.
+  enabled: false
+  # -- How frequently the Backup job should run. Cron Syntax, as supported by Kubernetes CronJobs
+  schedule: "@daily"
+  concurrencyPolicy: Forbid
+  restartPolicy: OnFailure
+  ttlSecondsAfterFinished: 300
+  activeDeadlineSeconds: 1800
+  backoffLimit: 1
+  parallelism: 1
+  imagePullPolicy: IfNotPresent
+  resources: {}
+  aws:
+    # -- For now, only AWS is supported. Setting this to `false` (while `backup.enabled` is `true`) will cause a deployment error.
+    enabled: true
+    # -- AWS Access Key. Must have the permissions to write to the target bucket.
+    accessKeyId: "my-aws-access-key-id"
+    # -- AWS Secret Key. Must have the permissions to write to the target bucket.
+    secretKey: "my-aws-secret-key"
+    # -- Target destination (absolute) in AWS S3, where the backup file should be written
+    s3:
+      destination: "s3://path/to/my/adguard-home-s3-export.json"
+
 bootstrapConfig:
   # -- AdGuard Home config. See [this page](https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration#configuration-file)
   bind_host: 0.0.0.0


### PR DESCRIPTION
AWS S3 is supported for now, but leaving room for backing up to other services as needed
