### PR TITLE
feat(ghost-export-to-s3): Allow to explicitly specify the base API endpoint of Ghost

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![adguard-home](https://img.shields.io/badge/adguard--home-0.13.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 [![atuin](https://img.shields.io/badge/atuin-0.8.0-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 [![dev-feed](https://img.shields.io/badge/dev--feed-2.4.0-blue)](https://artifacthub.io/packages/helm/rm3l/dev-feed)
-[![ghost-export-to-s3](https://img.shields.io/badge/ghost--export--to--s3-0.24.1-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)
+[![ghost-export-to-s3](https://img.shields.io/badge/ghost--export--to--s3-0.25.0-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)
 [![mac-oui](https://img.shields.io/badge/mac--oui-1.24.0-blue)](https://artifacthub.io/packages/helm/rm3l/mac-oui)
 [![service-names-port-numbers](https://img.shields.io/badge/service--names--port--numbers-0.26.0-blue)](https://artifacthub.io/packages/helm/rm3l/service-names-port-numbers)
 

--- a/charts/ghost-export-to-s3/Chart.yaml
+++ b/charts/ghost-export-to-s3/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.24.1
+version: 0.25.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/ghost-export-to-s3/README.md
+++ b/charts/ghost-export-to-s3/README.md
@@ -3,13 +3,13 @@
 Automated backups of headless Ghost Blogs to AWS S3.
 https://rm3l.org/leveraging-kubernetes-cronjobs-for-automated-backups-of-a-headless-ghost-blog-to-aws-s3/
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.24.1-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)
+[![Latest version](https://img.shields.io/badge/latest_version-0.25.0-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-ghost-export-to-s3 rm3l/ghost-export-to-s3 --version 0.24.1
+$ helm install my-ghost-export-to-s3 rm3l/ghost-export-to-s3 --version 0.25.0
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3?modal=install
@@ -34,8 +34,9 @@ See https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3?modal=install
 | cronJob.schedule | string | `"@daily"` | How frequently the Backup job should run. Cron Syntax, as supported by Kubernetes CronJobs |
 | cronJob.ttlSecondsAfterFinished | int | `300` |  |
 | fullnameOverride | string | `""` |  |
-| ghost.apiBaseUrl | string | `"https://my.ghost.blog/ghost"` | Base URL for the headless Ghost CMS targeted |
-| ghost.majorVersion | int | `4` | API Major Version. For example. this would be '4' if your version of Ghost is '4.7.0' |
+| ghost.apiBaseEndpoint | string | `""` | Base URL for the headless Ghost CMS targeted, including the version, if needed, e.g.: https://my.ghost.blog/ghost/v4 |
+| ghost.apiBaseUrl | string | `"https://my.ghost.blog/ghost"` | Base URL for the headless Ghost CMS targeted. **Deprecated**. Use `ghost.apiBaseEndpoint` instead. |
+| ghost.majorVersion | string | `"4"` | API Major Version. For example. this would be '4' if your version of Ghost is '4.7.0'. **Deprecated**. Use `ghost.apiBaseEndpoint` instead. |
 | ghost.password | string | `"my-ghost-password"` | Ghost CMS password |
 | ghost.username | string | `"my-ghost-username"` | Ghost CMS username |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/ghost-export-to-s3/templates/configmap.yaml
+++ b/charts/ghost-export-to-s3/templates/configmap.yaml
@@ -6,5 +6,6 @@ metadata:
     {{- include "ghost-export-to-s3.labels" . | nindent 4 }}
 data:
   GHOST_URL: "{{ .Values.ghost.apiBaseUrl }}"
+  GHOST_API_BASE_ENDPOINT: "{{ .Values.ghost.apiBaseEndpoint }}"
   GHOST_MAJOR_VERSION: "{{ .Values.ghost.majorVersion }}"
   S3_DESTINATION: "{{ .Values.aws.s3.destination }}"

--- a/charts/ghost-export-to-s3/templates/cronjob.yaml
+++ b/charts/ghost-export-to-s3/templates/cronjob.yaml
@@ -62,11 +62,11 @@ spec:
                 -d username='$(GHOST_AUTH_USERNAME)' \
                 -d password='$(GHOST_AUTH_PASSWORD)' \
                 -H 'Origin: k8s://$(POD_NAME)@$(POD_NAMESPACE)' \
-                '$(GHOST_URL)'/api/v$(GHOST_MAJOR_VERSION)/admin/session/ && \
+                '$(GHOST_API_BASE_ENDPOINT)/admin/session/' && \
               curl --fail -sSL -b /tmp/ghost-cookie.txt \
                 -H 'Origin: k8s://$(POD_NAME)@$(POD_NAMESPACE)' \
                 -H 'Content-Type: application/json' \
-                '$(GHOST_URL)'/api/v$(GHOST_MAJOR_VERSION)/admin/db/ \
+                '$(GHOST_API_BASE_ENDPOINT)/admin/db/' \
                 -o /data/ghost-export/ghost-export.json && \
               rm -rf /tmp/ghost-cookie.txt
             env:
@@ -78,6 +78,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.ghost.apiBaseEndpoint }}
+            - name: GHOST_API_BASE_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "ghost-export-to-s3.fullname" . }}
+                  key: GHOST_API_BASE_ENDPOINT
+            {{- else }}
             - name: GHOST_URL
               valueFrom:
                 configMapKeyRef:
@@ -88,6 +95,9 @@ spec:
                 configMapKeyRef:
                   name: {{ include "ghost-export-to-s3.fullname" . }}
                   key: GHOST_MAJOR_VERSION
+            - name: GHOST_API_BASE_ENDPOINT
+              value: "$(GHOST_URL)/api/v$(GHOST_MAJOR_VERSION)"
+            {{- end }}
             - name: GHOST_AUTH_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/ghost-export-to-s3/templates/cronjob.yaml
+++ b/charts/ghost-export-to-s3/templates/cronjob.yaml
@@ -52,7 +52,7 @@ spec:
 
           initContainers:
           - name: download-glorious-json-from-ghost
-            image: curlimages/curl:7.74.0
+            image: curlimages/curl:8.8.0
             imagePullPolicy: {{ .Values.cronJob.init.imagePullPolicy }}
             command:
             - /bin/sh
@@ -116,7 +116,7 @@ spec:
 
           containers:
           - name: export-ghost-json-to-s3
-            image: amazon/aws-cli:2.4.9
+            image: amazon/aws-cli:2.16.4
             imagePullPolicy: {{ .Values.cronJob.main.imagePullPolicy }}
             args:
             - s3

--- a/charts/ghost-export-to-s3/values.yaml
+++ b/charts/ghost-export-to-s3/values.yaml
@@ -3,14 +3,16 @@
 # Declare variables to be passed into your templates.
 
 ghost:
-  # -- Base URL for the headless Ghost CMS targeted
+  # -- Base URL for the headless Ghost CMS targeted. **Deprecated**. Use `ghost.apiBaseEndpoint` instead.
   apiBaseUrl: "https://my.ghost.blog/ghost"
+  # -- Base URL for the headless Ghost CMS targeted, including the version, if needed, e.g.: https://my.ghost.blog/ghost/v4
+  apiBaseEndpoint: ""
   # -- Ghost CMS username
   username: "my-ghost-username"
   # -- Ghost CMS password
   password: "my-ghost-password"
-  # -- API Major Version. For example. this would be '4' if your version of Ghost is '4.7.0'
-  majorVersion: 4
+  # -- API Major Version. For example. this would be '4' if your version of Ghost is '4.7.0'. **Deprecated**. Use `ghost.apiBaseEndpoint` instead.
+  majorVersion: "4"
 
 aws:
   # -- AWS Access Key. Must have the permissions to write to the target bucket.


### PR DESCRIPTION
Newer versions of Ghost seem to no longer require the major version to be part of the URL call.
This change is backward-compatible with the previous behavior, but it allows users to explicitly specify the full base API endpoint if needed.

- **feat(ghost-export-to-s3): Allow to explicitly specify the base API endpoint of Ghost**
- **Bump images**
- **Bump Chart version to 0.25.0**
- **fixup! feat(ghost-export-to-s3): Allow to explicitly specify the base API endpoint of Ghost**
- **fixup! feat(ghost-export-to-s3): Allow to explicitly specify the base API endpoint of Ghost**
- **Run pre-commit hook**
