### PR TITLE
feat(adguard-home): Expose `hostNetwork` field (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rm3l)](https://artifacthub.io/packages/search?repo=rm3l)
-[![adguard-home](https://img.shields.io/badge/adguard--home-0.15.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![adguard-home](https://img.shields.io/badge/adguard--home-0.17.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 [![atuin](https://img.shields.io/badge/atuin-0.9.0-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 [![dev-feed](https://img.shields.io/badge/dev--feed-2.4.0-blue)](https://artifacthub.io/packages/helm/rm3l/dev-feed)
 [![ghost-export-to-s3](https://img.shields.io/badge/ghost--export--to--s3-0.26.0-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 This Chart also provides automated backups of Adguard Home to services like AWS S3.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.16.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.17.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.16.0
+$ helm install my-adguard-home rm3l/adguard-home --version 0.17.0
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
@@ -182,6 +182,7 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | extraVolumeMounts | list | `[]` | Additional Volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` |  |
+| hostNetwork | bool | `false` | Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"adguard/adguardhome"` |  |
 | image.tag | string | `""` |  |

--- a/charts/adguard-home/ci/with-hostNetwork-and-custom-web-ui-port-values.yaml
+++ b/charts/adguard-home/ci/with-hostNetwork-and-custom-web-ui-port-values.yaml
@@ -1,0 +1,15 @@
+hostNetwork: true
+
+services:
+  http:
+    port: 8888
+  https:
+    enabled: false
+  dns:
+    enabled: false
+  dnsOverTls:
+    enabled: false
+  dnsOverQuic:
+    enabled: false
+  dnscrypt:
+    enabled: false

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -78,43 +79,56 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - /opt/adguardhome/AdGuardHome
+          - --no-check-update
+          - -c
+          - /opt/adguardhome/conf/AdGuardHome.yaml
+          - -w
+          - /opt/adguardhome/work
+          - --web-addr
+          - "0.0.0.0:{{ .Values.services.http.port }}"
           ports:
+          - name: admin
+            containerPort: {{ .Values.services.adminPanel.port }}
+            protocol: TCP
+          - name: http
+            containerPort: {{ .Values.services.http.port }}
+            protocol: TCP
+          {{- if .Values.services.https.enabled }}
+          - name: https
+            containerPort: {{ .Values.services.https.port }}
+            protocol: TCP
+          {{- end }}
+          {{- if .Values.services.dns.enabled }}
           - name: dns-tcp
-            containerPort: 53
+            containerPort: {{ .Values.services.dns.tcp.port }}
             protocol: TCP
           - name: dns-udp
-            containerPort: 53
-            protocol: UDP
-          - name: http
-            containerPort: 80
+            containerPort: {{ .Values.services.dns.udp.port }}
             protocol: TCP
-          - name: https
-            containerPort: 443
+          {{- end }}
+          {{- if .Values.services.dnsOverTls.enabled }}
+          - name: dot
+            containerPort: {{ .Values.services.dnsOverTls.port }}
             protocol: TCP
-          - name: https-udp
-            containerPort: 443
-            protocol: UDP
-          - name: admin
-            containerPort: 3000
-            protocol: TCP
-          - name: dns-over-tls
-            containerPort: 853
-            protocol: TCP
-          - name: dns-over-quic-1
-            containerPort: 784
-            protocol: UDP
-          - name: dns-over-quic-2
-            containerPort: 853
-            protocol: UDP
-          - name: dns-over-quic-3
-            containerPort: 8853
-            protocol: UDP
-          - name: dnscrypt
-            containerPort: 5443
+          {{- end }}
+          {{- if .Values.services.dnscrypt.enabled }}
+          - name: dnscrypt-tcp
+            containerPort: {{ .Values.services.dnscrypt.tcp.port }}
             protocol: TCP
           - name: dnscrypt-udp
-            containerPort: 5443
+            containerPort: {{ .Values.services.dnscrypt.udp.port }}
+            protocol: TCP
+          {{- end }}
+          {{- if .Values.services.dnsOverQuic.enabled }}
+          - name: doq-1
+            containerPort: {{ .Values.services.dnsOverQuic.port1.port }}
             protocol: UDP
+          - name: doq-2
+            containerPort: {{ .Values.services.dnsOverQuic.port2.port }}
+            protocol: UDP
+          {{- end }}
           # livenessProbe:
           #   httpGet:
           #     path: /

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -226,6 +226,9 @@ strategy: {}
   #   maxSurge: 1
   #   maxUnavailable: 33%
 
+# -- Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server.
+hostNetwork: false
+
 persistence:
   volumeClaimSpec:
     accessModes:


### PR DESCRIPTION
This is so that users can map container ports onto the host directly if possible.

This should allow enabling the DHCP Server from AdGuard Home

Fixes #68 