### PR TITLE
Add extraServices to adguard home chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rm3l)](https://artifacthub.io/packages/search?repo=rm3l)
-[![adguard-home](https://img.shields.io/badge/adguard--home-0.18.1-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![adguard-home](https://img.shields.io/badge/adguard--home-0.19.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 [![atuin](https://img.shields.io/badge/atuin-0.9.0-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 [![dev-feed](https://img.shields.io/badge/dev--feed-3.1.1-blue)](https://artifacthub.io/packages/helm/rm3l/dev-feed)
 [![ghost-export-to-s3](https://img.shields.io/badge/ghost--export--to--s3-0.26.0-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.2
+version: 0.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -179,6 +179,7 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | bootstrapConfig.whitelist_filters | list | `[]` |  |
 | bootstrapEnabled | bool | `true` | Whether to enable bootstrapping the AdguardHome config file using the content in bootstrapConfig |
 | defaultVolumeMountsEnabled | bool | `true` | Whether to add default volume mounts. |
+| extraServices | list | `[]` | Additional services |
 | extraVolumeMounts | list | `[]` | Additional Volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` |  |

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 This Chart also provides automated backups of Adguard Home to services like AWS S3.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.18.2-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.19.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.18.2
+$ helm install my-adguard-home rm3l/adguard-home --version 0.19.0
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install

--- a/charts/adguard-home/ci/with-service-extras-values.yaml
+++ b/charts/adguard-home/ci/with-service-extras-values.yaml
@@ -1,0 +1,27 @@
+extraServices:
+  - name: "dns-extra"
+    annotations: {}
+    spec:
+      type: NodePort
+      externalTrafficPolicy: Local
+      internalTrafficPolicy: Cluster
+      ports:
+        - name: dns-tcp
+          port: 53
+          protocol: TCP
+          targetPort: dns-tcp
+        - name: dns-udp
+          port: 53
+          protocol: UDP
+          targetPort: dns-udp
+  - name: "dot-extra"
+    annotations: {}
+    spec:
+      type: NodePort
+      externalTrafficPolicy: Local
+      internalTrafficPolicy: Cluster
+      ports:
+        - name: dot
+          port: 853
+          protocol: TCP
+          targetPort: dot

--- a/charts/adguard-home/templates/servicesextra.yaml
+++ b/charts/adguard-home/templates/servicesextra.yaml
@@ -1,0 +1,15 @@
+{{- range .Values.extraServices }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adguard-home.fullname" $ }}-{{ .name }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    {{- include "adguard-home.selectorLabels" $ | nindent 4 }}
+  {{- toYaml .spec | nindent 2 }}
+---
+{{- end }}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -171,6 +171,24 @@ services:
     # -- Dual-stack families for DNSCrypt; for dual-stack parameters see official kubernetes [dual-stack concept documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/).
     ipFamilies:
 
+# -- Additional services
+extraServices: []
+#  - name: "dns-extra"
+#    annotations: {}
+#    spec:
+#      type: LoadBalancer
+#      externalTrafficPolicy: Local
+#      internalTrafficPolicy: Cluster
+#      ports:
+#        - name: dns-tcp
+#          port: 53
+#          protocol: TCP
+#          targetPort: dns-tcp
+#        - name: dns-udp
+#          port: 53
+#          protocol: UDP
+#          targetPort: dns-udp
+
 ingresses:
   adminPanel:
     enabled: false


### PR DESCRIPTION
Hi!

This PR introduces the extraServices feature to the AdGuard Home Helm chart.  
It allows users to define additional services, which can be useful for exposing DNS services on multiple ports or load balancers.

An example of an extra service is included in the values file.

I’ve aimed to make the implementation clear, but I’m open to any feedback or suggestions!

Thanks