### PR TITLE
[atuin] CronJob template fixes

### DIFF
--- a/charts/atuin/Chart.yaml
+++ b/charts/atuin/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/atuin/README.md
+++ b/charts/atuin/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Atuin, the magical shell history.
 The server provides fully encrypted synchronization of the shell history across machines.
 https://github.com/ellie/atuin
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.10.0-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
+[![Latest version](https://img.shields.io/badge/latest_version-0.10.1-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-atuin rm3l/atuin --version 0.10.0
+$ helm install my-atuin rm3l/atuin --version 0.10.1
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/atuin?modal=install

--- a/charts/atuin/templates/cronjob.yaml
+++ b/charts/atuin/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.backup.enabled }}
 {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
 {{- else -}}
@@ -18,7 +19,7 @@ spec:
       parallelism: {{ .Values.backup.parallelism }}
       activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
       template:
-        metadata: 
+        metadata:
           annotations:
             checksum/secret: {{ include (print $.Template.BasePath "/backup.secret.yaml") . | sha256sum }}
             {{- with .Values.podAnnotations }}
@@ -70,15 +71,14 @@ spec:
           {{- end }}
 
           containers:
+          {{- if .Values.backup.aws.enabled }}
           - name: backup-config
             imagePullPolicy: {{ .Values.backup.imagePullPolicy }}
-            volumeMounts:
             volumeMounts:
             - mountPath: /config
               name: {{ include "atuin.fullname" . }}-config
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
-            {{- if .Values.backup.aws.enabled }}
             image: amazon/aws-cli:2.4.9
             args:
             - s3
@@ -102,18 +102,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "atuin.fullname" . }}-backup
                   key: S3_DESTINATION
-            {{- end }}
+          {{- end }}
 
           {{- if .Values.sqlite.enabled }}
           - name: backup-data-sqlite
             imagePullPolicy: {{ .Values.backup.imagePullPolicy }}
             volumeMounts:
-            volumeMounts:
             - mountPath: /data
               name: {{ include "atuin.fullname" . }}-data-sqlite
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
-            {{- if .Values.backup.aws.enabled }}
             image: amazon/aws-cli:2.4.9
             args:
             - s3
@@ -137,5 +135,5 @@ spec:
                 secretKeyRef:
                   name: {{ include "atuin.fullname" . }}-backup
                   key: S3_DESTINATION
-            {{- end }}
           {{- end }}
+{{- end }}


### PR DESCRIPTION
Like @7Kronos in #84, I don't rely on the backup cronjob. This PR wraps the cronjob with backup.enabled check to omit it. 

I also changed:
* Removed duplicate volumeMounts
* Moved the check of .Values.backup.aws.enabled to around the full container definition (otherwise it is invalid when false as image is missing)
* Removed the check of .Values.backup.aws.enabled inside the sqlite backup. 

Let me know if I should remove the two aws backup enabled changes. I don't use these so they are untested and there are still clear gaps in the logic so perhaps you prefer to keep the status quo.

## Summary by Sourcery

Improve the Atuin Helm chart CronJob template by adding a backup enablement check and cleaning up conditional logic

Enhancements:
- Restructure the CronJob template to conditionally render backup-related configurations based on backup enablement flags

Chores:
- Remove duplicate volume mounts
- Simplify AWS backup configuration conditionals