### PR TITLE
feat(wg-easy): Allow specifying the NodePort for the wg Service

### DIFF
--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wg-easy/README.md
+++ b/charts/wg-easy/README.md
@@ -55,6 +55,7 @@ See https://artifacthub.io/packages/helm/rm3l/wg-easy?modal=install
 | serviceAccount.name | string | `""` |  |
 | services.http.port | int | `51821` |  |
 | services.http.type | string | `"ClusterIP"` |  |
+| services.wireguard.nodePort | int | `30000` |  |
 | services.wireguard.port | int | `30000` |  |
 | services.wireguard.type | string | `"NodePort"` |  |
 | tolerations | list | `[]` |  |

--- a/charts/wg-easy/README.md
+++ b/charts/wg-easy/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for wg-easy, the easiest way to run WireGuard VPN.
 It also provides a Web-based Admin UI.
 https://github.com/wg-easy/wg-easy
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.1.0-blue)](https://artifacthub.io/packages/helm/rm3l/wg-easy)
+[![Latest version](https://img.shields.io/badge/latest_version-0.2.0-blue)](https://artifacthub.io/packages/helm/rm3l/wg-easy)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-wg-easy rm3l/wg-easy --version 0.1.0
+$ helm install my-wg-easy rm3l/wg-easy --version 0.2.0
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/wg-easy?modal=install

--- a/charts/wg-easy/templates/services.yaml
+++ b/charts/wg-easy/templates/services.yaml
@@ -8,7 +8,9 @@ spec:
   type: {{ .Values.services.wireguard.type }}
   ports:
     - port: {{ .Values.services.wireguard.port }}
+      {{- if eq .Values.services.wireguard.type "NodePort" }}
       nodePort: {{ .Values.services.wireguard.nodePort }}
+      {{- end }}
       targetPort: wg
       protocol: UDP
       name: wg

--- a/charts/wg-easy/templates/services.yaml
+++ b/charts/wg-easy/templates/services.yaml
@@ -8,6 +8,7 @@ spec:
   type: {{ .Values.services.wireguard.type }}
   ports:
     - port: {{ .Values.services.wireguard.port }}
+      nodePort: {{ .Values.services.wireguard.nodePort }}
       targetPort: wg
       protocol: UDP
       name: wg

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -45,6 +45,7 @@ services:
   wireguard:
     type: NodePort
     port: 30000
+    nodePort: 30000
   http:
     type: ClusterIP
     port: 51821


### PR DESCRIPTION
## Summary by Sourcery

Add support for explicitly specifying the NodePort for the WireGuard service in the Helm chart

New Features:
- Allow configurable NodePort for WireGuard service in wg-easy Helm chart

Documentation:
- Updated README.md to include new NodePort configuration option