### PR TITLE
Adding more options to Adguard chart

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.0
+version: 0.20.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -219,7 +219,6 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | persistence.existingClaim | string | `nil` |  |
 | persistence.volumeClaimSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | persistence.volumeClaimSpec.resources.requests.storage | string | `"1Gi"` |  |
-| persistence.volumeClaimSpec.storageClassName | string | `""` |  |
 | persistence.volumeClaimTemplates.enabled | bool | `false` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 This Chart also provides automated backups of Adguard Home to services like AWS S3.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.19.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.20.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.19.0
+$ helm install my-adguard-home rm3l/adguard-home --version 0.20.0
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -178,7 +178,9 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | bootstrapConfig.web_session_ttl | int | `720` |  |
 | bootstrapConfig.whitelist_filters | list | `[]` |  |
 | bootstrapEnabled | bool | `true` | Whether to enable bootstrapping the AdguardHome config file using the content in bootstrapConfig |
+| bootstrapExistingSecret | string | `""` | Use a provided secret with the Adguard config. Make sure it contains the field "AdGuardHome.yaml" |
 | defaultVolumeMountsEnabled | bool | `true` | Whether to add default volume mounts. |
+| deploymentType | string | `"Deployment"` |  |
 | extraServices | list | `[]` | Additional services |
 | extraVolumeMounts | list | `[]` | Additional Volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
@@ -212,9 +214,13 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | livenessProbe | string | `nil` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| persistence.emptyDir.sizeLimit | string | `"1Gi"` |  |
+| persistence.enabled | bool | `true` | Disabling this will mount the container with an emptyDir |
 | persistence.existingClaim | string | `nil` |  |
 | persistence.volumeClaimSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | persistence.volumeClaimSpec.resources.requests.storage | string | `"1Gi"` |  |
+| persistence.volumeClaimSpec.storageClassName | string | `""` |  |
+| persistence.volumeClaimTemplates.enabled | bool | `false` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -40,16 +40,22 @@ spec:
           secretName: {{ include "adguard-home.fullname" . }}
       {{- end }}
       - name: data-vol
+        {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           {{- if not .Values.persistence.existingClaim }}
           claimName: {{ include "adguard-home.fullname" . }}
           {{- else }}
           claimName: {{ .Values.persistence.existingClaim }}
-          {{- end -}}
+          {{- end }}
+        {{- else }}
+        emptyDir:
+          {{- if .Values.persistence.emptyDir.sizeLimit }}
+          sizeLimit: {{ .Values.persistence.emptyDir.sizeLimit }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
-
       {{- if .Values.bootstrapEnabled }}
       initContainers:
       - image: busybox:1.35
@@ -78,7 +84,6 @@ spec:
             cp -v /var/adguardhome-bootstrap/AdGuardHome.yaml /opt/adguardhome/conf/AdGuardHome.yaml
           fi
       {{- end }}
-
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -156,7 +161,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and (.Values.backup.enabled) (has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes)) }}
+      {{- if and .Values.persistence.enabled .Values.backup.enabled (has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes)) }}
       affinity:
         podAffinity:
           {{- /*

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.deploymentType "Deployment" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -178,3 +179,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.bootstrapEnabled }}
       - name: bootstrap-config-vol
         secret:
-          secretName: {{ include "adguard-home.fullname" . }}
+          secretName: {{ .Values.bootstrapExistingSecret | default (include "adguard-home.fullname" .) }}
       {{- end }}
       - name: data-vol
         {{- if .Values.persistence.enabled }}

--- a/charts/adguard-home/templates/secret.yaml
+++ b/charts/adguard-home/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bootstrapEnabled }}
+{{- if and .Values.bootstrapEnabled (not .Values.bootstrapExistingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/adguard-home/templates/statefulset.yaml
+++ b/charts/adguard-home/templates/statefulset.yaml
@@ -1,0 +1,180 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adguard-home.fullname" . }}
+  labels:
+    {{- include "adguard-home.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "adguard-home.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "adguard-home.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      priorityClassName: {{ .Values.priorityClassName }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "adguard-home.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      {{- if .Values.bootstrapEnabled }}
+      - name: bootstrap-config-vol
+        secret:
+          secretName: {{ include "adguard-home.fullname" . }}
+      {{- end }}
+      - name: data-vol
+        persistentVolumeClaim:
+          {{- if not .Values.persistence.existingClaim }}
+          claimName: {{ include "adguard-home.fullname" . }}
+          {{- else }}
+          claimName: {{ .Values.persistence.existingClaim }}
+          {{- end -}}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+
+      {{- if .Values.bootstrapEnabled }}
+      initContainers:
+      - image: busybox:1.35
+        name: configurator
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 100m
+            memory: "128Mi"
+          requests:
+            cpu: 100m
+            memory: "64Mi"
+        volumeMounts:
+        - name: bootstrap-config-vol
+          mountPath: /var/adguardhome-bootstrap
+        - name: data-vol
+          mountPath: /opt/adguardhome/conf
+          subPath: conf
+        command:
+        - /bin/sh
+        - "-c"
+        - |
+          if ls /opt/adguardhome/conf/AdGuardHome.yaml; then
+            echo "Existing file will NOT be altered: /opt/adguardhome/conf/AdGuardHome.yaml"
+          else
+            cp -v /var/adguardhome-bootstrap/AdGuardHome.yaml /opt/adguardhome/conf/AdGuardHome.yaml
+          fi
+      {{- end }}
+
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - /opt/adguardhome/AdGuardHome
+          - --no-check-update
+          - -c
+          - /opt/adguardhome/conf/AdGuardHome.yaml
+          - -w
+          - /opt/adguardhome/work
+          - --web-addr
+          - "0.0.0.0:{{ .Values.services.http.port }}"
+          ports:
+          - name: http
+            containerPort: {{ .Values.services.http.port }}
+            protocol: TCP
+          {{- if .Values.services.https.enabled }}
+          - name: https
+            containerPort: {{ .Values.services.https.port }}
+            protocol: TCP
+          {{- end }}
+          {{- if .Values.services.dns.enabled }}
+          - name: dns-tcp
+            containerPort: {{ .Values.services.dns.tcp.port }}
+            protocol: TCP
+          - name: dns-udp
+            containerPort: {{ .Values.services.dns.udp.port }}
+            protocol: UDP
+          {{- end }}
+          {{- if .Values.services.dnsOverTls.enabled }}
+          - name: dot
+            containerPort: {{ .Values.services.dnsOverTls.port }}
+            protocol: TCP
+          {{- end }}
+          {{- if .Values.services.dnscrypt.enabled }}
+          - name: dnscrypt-tcp
+            containerPort: {{ .Values.services.dnscrypt.tcp.port }}
+            protocol: TCP
+          - name: dnscrypt-udp
+            containerPort: {{ .Values.services.dnscrypt.udp.port }}
+            protocol: UDP
+          {{- end }}
+          {{- if .Values.services.dnsOverQuic.enabled }}
+          - name: doq-1
+            containerPort: {{ .Values.services.dnsOverQuic.port1.port }}
+            protocol: UDP
+          - name: doq-2
+            containerPort: {{ .Values.services.dnsOverQuic.port2.port }}
+            protocol: UDP
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.defaultVolumeMountsEnabled }}
+          - name: data-vol
+            mountPath: /opt/adguardhome/work
+            subPath: work
+          - name: data-vol
+            mountPath: /opt/adguardhome/conf
+            subPath: conf
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and (.Values.backup.enabled) (has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes)) }}
+      affinity:
+        podAffinity:
+          {{- /*
+          # Add soft affinity to avoid race condition when backup cronjob already runs and has the volume mounted
+          */}}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  {{- include "adguard-home.backupSelectorLabels" . | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      {{- else}}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/adguard-home/templates/statefulset.yaml
+++ b/charts/adguard-home/templates/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
       {{- if .Values.bootstrapEnabled }}
       - name: bootstrap-config-vol
         secret:
+          secretName: {{ .Values.bootstrapExistingSecret | default (include "adguard-home.fullname" .) }}
           secretName: {{ include "adguard-home.fullname" . }}
       {{- end }}
       {{- if and .Values.persistence.existingClaim (not .Values.persistence.volumeClaimTemplates.enabled) }}

--- a/charts/adguard-home/templates/statefulset.yaml
+++ b/charts/adguard-home/templates/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and (.Values.backup.enabled) (has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes)) }}
+      {{- if and .Values.persistence.enabled .Values.backup.enabled (has "ReadWriteOnce" (((.Values.persistence).volumeClaimSpec).accessModes)) }}
       affinity:
         podAffinity:
           {{- /*

--- a/charts/adguard-home/templates/statefulset.yaml
+++ b/charts/adguard-home/templates/statefulset.yaml
@@ -1,5 +1,6 @@
+{{- if eq .Values.deploymentType "StatefulSet" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "adguard-home.fullname" . }}
   labels:
@@ -8,11 +9,16 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  serviceName: {{ include "adguard-home.fullname" . }}
   selector:
     matchLabels:
       {{- include "adguard-home.selectorLabels" . | nindent 6 }}
-  strategy:
-    {{- toYaml .Values.strategy | nindent 4 }}
+  updateStrategy:
+    {{- if .Values.updateStrategy }}
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+    {{- else }}
+    type: RollingUpdate
+    {{- end }}
   template:
     metadata:
       labels:
@@ -38,17 +44,14 @@ spec:
         secret:
           secretName: {{ include "adguard-home.fullname" . }}
       {{- end }}
+      {{- if and .Values.persistence.existingClaim (not .Values.persistence.volumeClaimTemplates.enabled) }}
       - name: data-vol
         persistentVolumeClaim:
-          {{- if not .Values.persistence.existingClaim }}
-          claimName: {{ include "adguard-home.fullname" . }}
-          {{- else }}
           claimName: {{ .Values.persistence.existingClaim }}
-          {{- end -}}
+      {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
-
       {{- if .Values.bootstrapEnabled }}
       initContainers:
       - image: busybox:1.35
@@ -77,7 +80,6 @@ spec:
             cp -v /var/adguardhome-bootstrap/AdGuardHome.yaml /opt/adguardhome/conf/AdGuardHome.yaml
           fi
       {{- end }}
-
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -178,3 +180,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if and (not .Values.persistence.existingClaim) .Values.persistence.volumeClaimTemplates.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data-vol
+      labels:
+        {{- include "adguard-home.labels" . | nindent 8 }}
+    spec:
+      {{- toYaml .Values.persistence.volumeClaimSpec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/adguard-home/templates/statefulset.yaml
+++ b/charts/adguard-home/templates/statefulset.yaml
@@ -43,7 +43,6 @@ spec:
       - name: bootstrap-config-vol
         secret:
           secretName: {{ .Values.bootstrapExistingSecret | default (include "adguard-home.fullname" .) }}
-          secretName: {{ include "adguard-home.fullname" . }}
       {{- end }}
       {{- if and .Values.persistence.existingClaim (not .Values.persistence.volumeClaimTemplates.enabled) }}
       - name: data-vol

--- a/charts/adguard-home/values.schema.json
+++ b/charts/adguard-home/values.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "deploymentType": {
+      "type": "string",
+      "enum": [
+        "Deployment",
+        "StatefulSet"
+      ],
+      "description": "Type of Kubernetes workload to deploy. Must be either 'Deployment' or 'StatefulSet'."
+    }
+  },
+  "required": [
+    "deploymentType"
+  ]
+}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -295,7 +295,6 @@ persistence:
     enabled: false  # Set to true to use volumeClaimTemplates, false to use existing PVC
   emptyDir:
     sizeLimit: 1Gi
-      
 
 backup:
   # -- Note that this depends on the Access Mode set for the persistent volume claim (PVC) specified.

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -289,7 +289,7 @@ persistence:
     resources:
       requests:
         storage: 1Gi
-    storageClassName: "" # Optional: specify storage class
+    # storageClassName: "" # Optional: specify storage class
   # Use when deploymentType is StatefulSet
   volumeClaimTemplates:
     enabled: false  # Set to true to use volumeClaimTemplates, false to use existing PVC

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Choose deployment type: Deployment or StatefulSet
+deploymentType: Deployment
+
 replicaCount: 1
 
 image:
@@ -284,6 +287,11 @@ persistence:
     resources:
       requests:
         storage: 1Gi
+    storageClassName: "" # Optional: specify storage class
+  # Use when deploymentType is StatefulSet
+  volumeClaimTemplates:
+    enabled: false  # Set to true to use volumeClaimTemplates, false to use existing PVC
+      
 
 backup:
   # -- Note that this depends on the Access Mode set for the persistent volume claim (PVC) specified.

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -323,7 +323,8 @@ backup:
 
 # -- Whether to enable bootstrapping the AdguardHome config file using the content in bootstrapConfig
 bootstrapEnabled: true
-
+# -- Use a provided secret with the Adguard config. Make sure it contains the field "AdGuardHome.yaml"
+bootstrapExistingSecret: ""
 bootstrapConfig:
   # -- AdGuard Home config. See [this page](https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration#configuration-file)
   bind_host: 0.0.0.0

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -291,6 +291,8 @@ persistence:
   # Use when deploymentType is StatefulSet
   volumeClaimTemplates:
     enabled: false  # Set to true to use volumeClaimTemplates, false to use existing PVC
+  emptyDir:
+    sizeLimit: 1Gi
       
 
 backup:

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -280,6 +280,8 @@ readinessProbe: null
 startupProbe: null
 
 persistence:
+# -- Disabling this will mount the container with an emptyDir
+  enabled: true
   existingClaim: null
   volumeClaimSpec:
     accessModes:


### PR DESCRIPTION
I have added some options to the chart:

- Deploying the chart using StatefulSets in addition to the Deployment
- Deploying the chart without any persistent store
- Added the option to provide your own Bootstrap secret

I've tested all these options, it should not cause any breaking changes with current deployments.

Closes #105

## Summary by Sourcery

Extend the AdGuard Home Helm chart by adding a deploymentType option to choose between Deployment or StatefulSet, enabling an emptyDir-based installation without persistent storage, and allowing users to reference a pre-existing bootstrap secret.

New Features:
- Add optional StatefulSet deployment type alongside Deployment
- Allow disabling persistence to use an emptyDir volume
- Support supplying an existing bootstrap secret for configuration