### PR TITLE
feat(atuin): Use native sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 
 # End of https://www.toptal.com/developers/gitignore/api/helm
 
+.idea/

--- a/charts/atuin/Chart.yaml
+++ b/charts/atuin/Chart.yaml
@@ -18,14 +18,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # https://github.com/atuinsh/atuin/pkgs/container/atuin
-appVersion: "18.3.0"
+appVersion: "18.8.0"
 
 # Issue with name. See discussion here : https://github.com/helm/chart-testing/issues/192
 maintainers:

--- a/charts/atuin/README.md
+++ b/charts/atuin/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Atuin, the magical shell history.
 The server provides fully encrypted synchronization of the shell history across machines.
 https://github.com/ellie/atuin
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.10.1-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
+[![Latest version](https://img.shields.io/badge/latest_version-0.10.2-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-atuin rm3l/atuin --version 0.10.1
+$ helm install my-atuin rm3l/atuin --version 0.10.2
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/atuin?modal=install
@@ -33,7 +33,7 @@ See https://artifacthub.io/packages/helm/rm3l/atuin?modal=install
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | backup.activeDeadlineSeconds | int | `1800` |  |
 | backup.aws.accessKeyId | string | `"my-aws-access-key-id"` | AWS Access Key. Must have the permissions to write to the target bucket. |
-| backup.aws.enabled | bool | `true` | For now, only AWS is supported. Setting this to `false` (while `sqlite.backup.enabled` is `true`) will cause a deployment error. |
+| backup.aws.enabled | bool | `true` | For now, only AWS is supported. Setting this to `false` (while `backup.enabled` is `true`) will cause a deployment error. |
 | backup.aws.s3 | object | `{"destination":"s3://path/to/my/atuin-sqlite-backup-bucket"}` | Target destination bucket (absolute) in AWS S3, where the backup resources should be written |
 | backup.aws.secretKey | string | `"my-aws-secret-key"` | AWS Secret Key. Must have the permissions to write to the target bucket. |
 | backup.backoffLimit | int | `1` |  |
@@ -45,6 +45,8 @@ See https://artifacthub.io/packages/helm/rm3l/atuin?modal=install
 | backup.restartPolicy | string | `"OnFailure"` |  |
 | backup.schedule | string | `"@daily"` | How frequently the Backup job should run. Cron Syntax, as supported by Kubernetes CronJobs |
 | backup.ttlSecondsAfterFinished | int | `300` |  |
+| env[0].name | string | `"RUST_LOG"` |  |
+| env[0].value | string | `"info,atuin_server=info"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/atuinsh/atuin"` |  |
@@ -75,10 +77,7 @@ See https://artifacthub.io/packages/helm/rm3l/atuin?modal=install
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| sqlite.enabled | bool | `false` | Experimental support of SQLite. Enable this and disable postgresql.enabled to use it. More details at https://github.com/conradludgate/atuin-server-sqlite |
-| sqlite.image.pullPolicy | string | `"Always"` |  |
-| sqlite.image.repository | string | `"ghcr.io/conradludgate/atuin-server-sqlite"` |  |
-| sqlite.image.tag | string | `"v18.3.0"` |  |
+| sqlite.enabled | bool | `false` |  |
 | sqlite.persistence.volumeClaimSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | sqlite.persistence.volumeClaimSpec.resources.requests.storage | string | `"1Gi"` |  |
 | storage.config.volumeClaimSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |

--- a/charts/atuin/templates/deployment.yaml
+++ b/charts/atuin/templates/deployment.yaml
@@ -51,13 +51,8 @@ spec:
             - start
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.sqlite.enabled }}
-          image: "{{ .Values.sqlite.image.repository }}:{{ .Values.sqlite.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.sqlite.image.pullPolicy }}
-          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- end }}
           env:
             - name: ATUIN_DB_URI
             {{- if .Values.sqlite.enabled }}
@@ -75,6 +70,9 @@ spec:
               value: "{{ .Values.service.port }}"
             - name: ATUIN_OPEN_REGISTRATION
               value: "{{ .Values.atuin.openRegistration }}"
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: app-port
               containerPort: {{ .Values.service.port }}

--- a/charts/atuin/values.yaml
+++ b/charts/atuin/values.yaml
@@ -93,13 +93,13 @@ storage:
 atuin:
   openRegistration: true
 
+# Custom env variables
+env:
+  - name: RUST_LOG
+    value: info,atuin_server=info
+
 sqlite:
-  # -- Experimental support of SQLite. Enable this and disable postgresql.enabled to use it. More details at https://github.com/conradludgate/atuin-server-sqlite
   enabled: false
-  image:
-    repository: ghcr.io/conradludgate/atuin-server-sqlite
-    pullPolicy: Always
-    tag: "v18.3.0"
   persistence:
     volumeClaimSpec:
       accessModes:
@@ -137,7 +137,7 @@ backup:
   imagePullPolicy: IfNotPresent
   resources: {}
   aws:
-    # -- For now, only AWS is supported. Setting this to `false` (while `sqlite.backup.enabled` is `true`) will cause a deployment error.
+    # -- For now, only AWS is supported. Setting this to `false` (while `backup.enabled` is `true`) will cause a deployment error.
     enabled: true
     # -- AWS Access Key. Must have the permissions to write to the target bucket.
     accessKeyId: "my-aws-access-key-id"


### PR DESCRIPTION
Upstream recently merged sqlite support [1]. Also add arbitrary environment variable support.

[1] https://github.com/atuinsh/atuin/pull/2770

## Summary by Sourcery

Enable native SQLite support in the Atuin Helm chart, consolidate on the main server image, add custom environment variable support, and bump chart and application versions

New Features:
- Allow defining custom environment variables for the Atuin server in values.yaml

Enhancements:
- Remove the separate SQLite server image configuration and always use the primary Atuin server image with built-in SQLite support
- Simplify the Helm deployment template by unifying image selection logic regardless of sqlite.enabled

Build:
- Update Helm chart version to 0.10.2 and application version to "2741338"