### PR TITLE
ntfy: Fix server configuration filename

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for ntfy, a simple HTTP-based pub-sub notification service.
 This Chart also provides automated backups of ntfy to services like AWS S3.
 https://github.com/binwiederhier/ntfy
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.1.0-blue)](https://artifacthub.io/packages/helm/rm3l/ntfy)
+[![Latest version](https://img.shields.io/badge/latest_version-0.1.1-blue)](https://artifacthub.io/packages/helm/rm3l/ntfy)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-ntfy rm3l/ntfy --version 0.1.0
+$ helm install my-ntfy rm3l/ntfy --version 0.1.1
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/ntfy?modal=install

--- a/charts/ntfy/templates/configmap.yaml
+++ b/charts/ntfy/templates/configmap.yaml
@@ -7,6 +7,6 @@ metadata:
   labels:
     {{- include "ntfy.labels" . | nindent 4 }}
 data:
-  server.yaml: |
+  server.yml: |
 {{ toYaml .Values.config.sample | indent 4 }}
 {{- end }}


### PR DESCRIPTION
The default configuration path used by `ntfy` is `/etc/ntfy/server.yml`, not `server.yaml` (with `a`).

Change the key in the chart-generated ConfigMap to create the configuration with the correct filename.

## Summary by Sourcery

Bug Fixes:
- Correct the default ntfy server configuration filename in the Helm chart ConfigMap from server.yaml to server.yml.