### PR TITLE
feat: add httproute support to adguard

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.2
+version: 0.23.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -4,13 +4,14 @@ Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 This Chart also provides automated backups of Adguard Home to services like AWS S3.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.21.2-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.23.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.21.2
+$ helm install my-adguard-home rm3l/adguard-home --version 0.23.0
+```
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
@@ -186,6 +187,14 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server. |
+| httproutes.http.enabled | bool | `false` |  |
+| httproutes.http.hostnames | list | `[]` |  |
+| httproutes.http.parentRefs | list | `[]` |  |
+| httproutes.http.rules | list | `[]` |  |
+| httproutes.https.enabled | bool | `false` |  |
+| httproutes.https.hostnames | list | `[]` |  |
+| httproutes.https.parentRefs | list | `[]` |  |
+| httproutes.https.rules | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"adguard/adguardhome"` |  |
 | image.tag | string | `""` |  |

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -12,7 +12,6 @@ https://github.com/AdguardTeam/AdGuardHome
 $ helm repo add rm3l https://helm-charts.rm3l.org
 $ helm install my-adguard-home rm3l/adguard-home --version 0.23.0
 ```
-```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 

--- a/charts/adguard-home/templates/httproutes.yaml
+++ b/charts/adguard-home/templates/httproutes.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.httproutes.http.enabled -}}
+{{- $fullName := include "adguard-home.fullname" . -}}
+{{- $svcPort := .Values.services.http.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-http
+  labels:
+    {{- include "adguard-home.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httproutes.http.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml .Values.httproutes.http.hostnames | nindent 4 }}
+  rules:
+    {{- if .Values.httproutes.http.rules }}
+    {{- toYaml .Values.httproutes.http.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}-http
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}
+---
+{{- if .Values.httproutes.https.enabled -}}
+{{- $fullName := include "adguard-home.fullname" . -}}
+{{- $svcPort := .Values.services.https.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-https
+  labels:
+    {{- include "adguard-home.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httproutes.https.parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml .Values.httproutes.https.hostnames | nindent 4 }}
+  rules:
+    {{- if .Values.httproutes.https.rules }}
+    {{- toYaml .Values.httproutes.https.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}-https
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -211,6 +211,34 @@ ingresses:
     #    hosts:
     #      - chart-example.
 
+httproutes:
+  http:
+    enabled: false
+    parentRefs: []
+    hostnames: []
+    # - adguard-home-example.local
+    rules: []
+    # - matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    #   backendRefs:
+    #   - name: adguard-home-http
+    #     port: 80
+  https:
+    enabled: false
+    parentRefs: []
+    hostnames: []
+    # - adguard-home-example.local
+    rules: []
+    # - matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /
+    #   backendRefs:
+    #   - name: adguard-home-https
+    #     port: 443
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce configurable httproutes values for HTTP and HTTPS to control parentRefs, hostnames, and routing rules for AdGuard Home services.