### PR TITLE
feat: add httproute annotations

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.0
+version: 0.24.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 This Chart also provides automated backups of Adguard Home to services like AWS S3.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.23.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.24.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.23.0
+$ helm install my-adguard-home rm3l/adguard-home --version 0.24.0
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
@@ -186,10 +186,12 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server. |
+| httproutes.http.annotations | object | `{}` |  |
 | httproutes.http.enabled | bool | `false` |  |
 | httproutes.http.hostnames | list | `[]` |  |
 | httproutes.http.parentRefs | list | `[]` |  |
 | httproutes.http.rules | list | `[]` |  |
+| httproutes.https.annotations | object | `{}` |  |
 | httproutes.https.enabled | bool | `false` |  |
 | httproutes.https.hostnames | list | `[]` |  |
 | httproutes.https.parentRefs | list | `[]` |  |

--- a/charts/adguard-home/templates/httproutes.yaml
+++ b/charts/adguard-home/templates/httproutes.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ $fullName }}-http
   labels:
     {{- include "adguard-home.labels" . | nindent 4 }}
+{{- with .Values.httproutes.http.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   parentRefs:
     {{- toYaml .Values.httproutes.http.parentRefs | nindent 4 }}
@@ -35,6 +39,10 @@ metadata:
   name: {{ $fullName }}-https
   labels:
     {{- include "adguard-home.labels" . | nindent 4 }}
+{{- with .Values.httproutes.https.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   parentRefs:
     {{- toYaml .Values.httproutes.https.parentRefs | nindent 4 }}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -214,6 +214,7 @@ ingresses:
 httproutes:
   http:
     enabled: false
+    annotations: {}
     parentRefs: []
     hostnames: []
     # - adguard-home-example.local
@@ -227,6 +228,7 @@ httproutes:
     #     port: 80
   https:
     enabled: false
+    annotations: {}
     parentRefs: []
     hostnames: []
     # - adguard-home-example.local


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump
- [ ] Dependency update

## Chart(s) Affected
<!-- List the chart(s) modified in this PR -->
- Adguard

## Related Issues
<!-- Link any related issues using #issue_number -->
Fixes #
Closes #

## Changes Made
<!-- List the specific changes made in this PR -->
- Add chart annotations to httproutes like ingress

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] Tested with `helm template`
- [X] Tested with `helm lint`
- [X] Tested fresh installation on Kubernetes cluster
- [X] Tested upgrade from previous version
- [X] Verified all configuration options work as expected

### Test Configuration
<!-- Provide relevant parts of your test values.yaml if applicable -->
```yaml
# Test configuration used
```

### Test Environment
- **Kubernetes Version:** v1.34.2
- **Helm Version:** 4.0.1
- **Platform:** K3s

## Checklist
<!-- Mark completed items with an 'x' -->
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [X] My code follows the style guidelines of this project
- [X] I have updated the chart version in `Chart.yaml` (for chart changes)
- [] I have updated the `README.md` (if applicable)
- [X] I have updated the `values.yaml` with appropriate defaults and comments
- [X] I have tested my changes locally
- [X] My changes generate no new warnings
- [X] I have checked that my changes don't introduce security vulnerabilities

## Summary by Sourcery

Add configurable annotations support to Adguard httproute resources and bump the chart version.

New Features:
- Allow configuring annotations on HTTP and HTTPS HTTPRoute resources via values.yaml.

Enhancements:
- Initialize default empty annotations maps for HTTP and HTTPS HTTPRoute configurations in values.yaml.

Build:
- Bump Adguard chart version to 0.24.0 to release the new annotations functionality.