### PR TITLE
chore(atuin): Update to 18.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/rm3l)](https://artifacthub.io/packages/search?repo=rm3l)
 [![adguard-home](https://img.shields.io/badge/adguard--home-0.19.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
-[![atuin](https://img.shields.io/badge/atuin-0.10.3-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
+[![atuin](https://img.shields.io/badge/atuin-0.10.4-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 [![dev-feed](https://img.shields.io/badge/dev--feed-3.1.2-blue)](https://artifacthub.io/packages/helm/rm3l/dev-feed)
 [![ghost-export-to-s3](https://img.shields.io/badge/ghost--export--to--s3-0.26.0-blue)](https://artifacthub.io/packages/helm/rm3l/ghost-export-to-s3)
 [![kresus](https://img.shields.io/badge/kresus-0.2.1-blue)](https://artifacthub.io/packages/helm/rm3l/kresus)

--- a/charts/atuin/Chart.yaml
+++ b/charts/atuin/Chart.yaml
@@ -18,14 +18,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.3
+version: 0.10.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # https://github.com/atuinsh/atuin/pkgs/container/atuin
-appVersion: "18.8.0"
+appVersion: "18.10.0"
 
 # Issue with name. See discussion here : https://github.com/helm/chart-testing/issues/192
 maintainers:

--- a/charts/atuin/README.md
+++ b/charts/atuin/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Atuin, the magical shell history.
 The server provides fully encrypted synchronization of the shell history across machines.
 https://github.com/ellie/atuin
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.10.3-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
+[![Latest version](https://img.shields.io/badge/latest_version-0.10.4-blue)](https://artifacthub.io/packages/helm/rm3l/atuin)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-atuin rm3l/atuin --version 0.10.3
+$ helm install my-atuin rm3l/atuin --version 0.10.4
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/atuin?modal=install


### PR DESCRIPTION
## Summary by Sourcery

Update the Atuin Helm chart metadata to reference the new application release.

Build:
- Bump the chart version to 0.10.4 for a new release of the Atuin Helm chart.
- Update the Atuin container appVersion reference from 18.8.0 to 18.10.0.