### PR TITLE
fix(adguard-home): default container images to FQDN for K8s 1.34+

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.24.0
+version: 0.24.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -4,13 +4,13 @@ Unofficial Chart for Adguard Home, the network-wide ad and tracking blocker.
 This Chart also provides automated backups of Adguard Home to services like AWS S3.
 https://github.com/AdguardTeam/AdGuardHome
 
-[![Latest version](https://img.shields.io/badge/latest_version-0.24.0-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
+[![Latest version](https://img.shields.io/badge/latest_version-0.24.1-blue)](https://artifacthub.io/packages/helm/rm3l/adguard-home)
 
 ## Installation
 
 ```bash
 $ helm repo add rm3l https://helm-charts.rm3l.org
-$ helm install my-adguard-home rm3l/adguard-home --version 0.24.0
+$ helm install my-adguard-home rm3l/adguard-home --version 0.24.1
 ```
 
 See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
@@ -186,6 +186,7 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server. |
+| global.imageRegistry | string | `""` | Global container image registry. Used as a fallback when `image.registry` is not set. |
 | httproutes.http.annotations | object | `{}` |  |
 | httproutes.http.enabled | bool | `false` |  |
 | httproutes.http.hostnames | list | `[]` |  |
@@ -197,6 +198,7 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | httproutes.https.parentRefs | list | `[]` |  |
 | httproutes.https.rules | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `"docker.io"` | Container image registry (FQDN). If `image.repository` already includes a registry, this value is ignored. |
 | image.repository | string | `"adguard/adguardhome"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -185,8 +185,8 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | extraVolumeMounts | list | `[]` | Additional Volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` |  |
-| hostNetwork | bool | `false` | Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server. |
 | global.imageRegistry | string | `""` | Global container image registry. Used as a fallback when `image.registry` is not set. |
+| hostNetwork | bool | `false` | Host networking requested for the pod. Beware that setting this to true requires all container ports declared in the pod to be free on the node. This can be useful for example to expose AdGuard Home as a DHCP Server. |
 | httproutes.http.annotations | object | `{}` |  |
 | httproutes.http.enabled | bool | `false` |  |
 | httproutes.http.hostnames | list | `[]` |  |
@@ -198,7 +198,7 @@ See https://artifacthub.io/packages/helm/rm3l/adguard-home?modal=install
 | httproutes.https.parentRefs | list | `[]` |  |
 | httproutes.https.rules | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"docker.io"` | Container image registry (FQDN). If `image.repository` already includes a registry, this value is ignored. |
+| image.registry | string | `"docker.io"` | If `image.repository` already includes a registry (e.g. `ghcr.io/org/image`), this value is ignored. |
 | image.repository | string | `"adguard/adguardhome"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/adguard-home/templates/_helpers.tpl
+++ b/charts/adguard-home/templates/_helpers.tpl
@@ -80,3 +80,49 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the image registry to use, preferring:
+1) .Values.image.registry
+2) .Values.global.imageRegistry
+3) docker.io
+*/}}
+{{- define "adguard-home.imageRegistry" -}}
+{{- default "docker.io" (coalesce .Values.image.registry .Values.global.imageRegistry) -}}
+{{- end -}}
+
+{{/*
+Return true when the repository already contains a registry (FQDN, localhost, or host:port).
+Logic based on Docker's reference rules: if the first path component contains '.' or ':'
+or is exactly 'localhost', it is treated as a registry host.
+*/}}
+{{- define "adguard-home.repositoryHasRegistry" -}}
+{{- $repo := (toString .) -}}
+{{- $first := (first (splitList "/" $repo)) -}}
+{{- if or (eq $first "localhost") (contains "." $first) (contains ":" $first) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return an image repository qualified with a registry (FQDN).
+If .Values.image.repository already contains a registry, it is returned as-is.
+Otherwise, the configured registry is prepended.
+*/}}
+{{- define "adguard-home.imageRepository" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if eq (include "adguard-home.repositoryHasRegistry" $repo | trim) "true" -}}
+{{- $repo -}}
+{{- else -}}
+{{- printf "%s/%s" (include "adguard-home.imageRegistry" .) $repo -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the fully qualified AdGuard Home image (repository + tag).
+*/}}
+{{- define "adguard-home.image" -}}
+{{- printf "%s:%s" (include "adguard-home.imageRepository" .) (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/adguard-home/templates/cronjob.yaml
+++ b/charts/adguard-home/templates/cronjob.yaml
@@ -78,7 +78,7 @@ spec:
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
             {{- if .Values.backup.aws.enabled }}
-            image: amazon/aws-cli:2.4.9
+            image: docker.io/amazon/aws-cli:2.4.9
             args:
             - s3
             - cp

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       {{- if .Values.bootstrapEnabled }}
       initContainers:
-      - image: busybox:1.35
+      - image: docker.io/busybox:1.35
         name: configurator
         imagePullPolicy: Always
         resources:
@@ -88,7 +88,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "adguard-home.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - /opt/adguardhome/AdGuardHome

--- a/charts/adguard-home/templates/statefulset.yaml
+++ b/charts/adguard-home/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       {{- if .Values.bootstrapEnabled }}
       initContainers:
-      - image: busybox:1.35
+      - image: docker.io/busybox:1.35
         name: configurator
         imagePullPolicy: Always
         resources:
@@ -84,7 +84,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "adguard-home.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - /opt/adguardhome/AdGuardHome

--- a/charts/adguard-home/templates/tests/test-connection.yaml
+++ b/charts/adguard-home/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: docker.io/busybox:1.35
       command: ['wget']
       args: ['{{ include "adguard-home.fullname" . }}-http:{{ .Values.services.http.port }}']
   restartPolicy: Never

--- a/charts/adguard-home/values.schema.json
+++ b/charts/adguard-home/values.schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": {
+          "type": "string",
+          "description": "Global container image registry. Used as a fallback when image.registry is not set."
+        }
+      }
+    },
     "deploymentType": {
       "type": "string",
       "enum": [
@@ -9,6 +18,24 @@
         "StatefulSet"
       ],
       "description": "Type of Kubernetes workload to deploy. Must be either 'Deployment' or 'StatefulSet'."
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Container image registry (FQDN). If image.repository already includes a registry, this value is ignored."
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        }
+      }
     }
   },
   "required": [

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -7,7 +7,14 @@ deploymentType: Deployment
 
 replicaCount: 1
 
+global:
+  # -- Global container image registry. Used as a fallback when `image.registry` is not set.
+  imageRegistry: ""
+
 image:
+  # -- Container image registry (FQDN). Starting with Kubernetes 1.34 / CRI-O 1.34, short image names are rejected.
+  # -- If `image.repository` already includes a registry (e.g. `ghcr.io/org/image`), this value is ignored.
+  registry: docker.io
   repository: adguard/adguardhome
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
## Description
Kubernetes 1.34 / CRI-O 1.34 no longer accept short image names (e.g. `busybox`, `adguard/adguardhome`). This PR makes `charts/adguard-home` render fully-qualified image references by default (e.g. `docker.io/...`) while staying backward compatible for users who already provide a registry in `image.repository`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Chart version bump
- [ ] Dependency update

## Chart(s) Affected
- adguard-home

## Related Issues
Fixes #
Closes #

## Changes Made
- Added `image.registry` (default `docker.io`) and `global.imageRegistry` fallback to ensure FQDN image refs by default.
- Updated workload templates to render the main container image via a helper that preserves existing full registries.
- Qualified embedded images used by the chart (bootstrap initContainer, backup CronJob, and Helm test pod) with `docker.io/...`.
- Bumped chart version to `0.24.1` and updated chart docs/schema accordingly.

## Breaking Changes
None.

## Testing
- [x] Tested with `helm template`
- [x] Tested with `helm lint`
- [ ] Tested fresh installation on Kubernetes cluster
- [ ] Tested upgrade from previous version
- [ ] Verified all configuration options work as expected

### Test Configuration
```yaml
# default values

## Summary by Sourcery

Ensure AdGuard Home Helm chart uses fully qualified container image references by default while maintaining compatibility with existing configurations.

New Features:
- Add configurable image.registry value with global.imageRegistry fallback to control the container image registry.

Bug Fixes:
- Fix incompatibility with Kubernetes 1.34+ and CRI-O 1.34+ by avoiding short image names for all images used by the chart.

Enhancements:
- Introduce helper templates to build fully qualified AdGuard Home image references without breaking existing repository settings.
- Update embedded image references in init containers, backup CronJob, and Helm test pod to use docker.io-qualified images.
- Bump chart version to 0.24.1 and refresh associated README metadata and values schema entries.

Documentation:
- Document new image.registry and global.imageRegistry values and update README examples to reference chart version 0.24.1.